### PR TITLE
Simple mrdivide

### DIFF
--- a/modules/core/linalg/include/nt2/linalg/functions/mrdivide.hpp
+++ b/modules/core/linalg/include/nt2/linalg/functions/mrdivide.hpp
@@ -1,0 +1,86 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_LINALG_FUNCTIONS_MRDIVIDE_HPP_INCLUDED
+#define NT2_LINALG_FUNCTIONS_MRDIVIDE_HPP_INCLUDED
+
+#include <nt2/include/functor.hpp>
+#include <nt2/sdk/meta/value_as.hpp>
+#include <nt2/core/container/dsl/size.hpp>
+#include <nt2/core/container/dsl/value_type.hpp>
+#include <nt2/sdk/meta/tieable_hierarchy.hpp>
+#include <nt2/sdk/meta/size_as.hpp>
+#include <nt2/sdk/meta/value_as.hpp>
+
+namespace nt2
+{
+  namespace tag
+  {
+    struct mrdivide_ : ext::tieable_<mrdivide_>
+    {
+      typedef ext::tieable_<mrdivide_>  parent;
+      template<class... Args>
+      static BOOST_FORCEINLINE BOOST_AUTO_DECLTYPE dispatch(Args&&... args)
+      BOOST_AUTO_DECLTYPE_BODY( dispatching_mrdivide_( ext::adl_helper(), static_cast<Args&&>(args)... ) )
+    };
+  }
+  namespace ext
+  {
+    template<class Site>
+    BOOST_FORCEINLINE generic_dispatcher<tag::mrdivide_, Site> dispatching_mrdivide_(adl_helper, boost::dispatch::meta::unknown_<Site>, ...)
+    {
+      return generic_dispatcher<tag::mrdivide_, Site>();
+    }
+    template<class... Args>
+    struct impl_mrdivide_;
+  }
+
+  /**
+   * @briefsolve a (left) linear system xa = b (x unknown)
+   *
+   * solve for x the system xa = b ( c = ctrans(linsolve(ctrans(a), ctrans(b));
+   *
+   * @code
+   *      T x = mrdivide(b, a {, option});
+   * @encode
+   *
+   *    is similar to
+   *
+   * @code
+   *      T x = ctrans(linsolve(ctrans(a), ctrans(b) {, option});
+   * @encode
+   *
+   * Note : @code tie(x, r) = mrdivide(b, a {, option}); @encode
+   * also returns the inverse condition number r of a
+
+   * @see @{linsolve} @{mldivide}
+
+   * @param  b right hand side of the equation
+   * @param  a matrix of the equation
+   *
+   * @return the solution of the system
+   **/
+
+  NT2_FUNCTION_IMPLEMENTATION(tag::mrdivide_, mrdivide, 2)
+  NT2_FUNCTION_IMPLEMENTATION(tag::mrdivide_, mrdivide, 3)
+}
+
+namespace nt2 { namespace ext
+{
+  template<class Domain, int N, class Expr>
+  struct  size_of<tag::mrdivide_,Domain,N,Expr>
+        : meta::size_as<Expr,1>
+  {};
+
+  template<class Domain, int N, class Expr>
+  struct  value_type<tag::mrdivide_,Domain,N,Expr>
+        : meta::value_as<Expr,0>
+  {};
+
+} }
+
+#endif

--- a/modules/core/linalg/include/nt2/linalg/functions/mrdivide.hpp
+++ b/modules/core/linalg/include/nt2/linalg/functions/mrdivide.hpp
@@ -45,13 +45,13 @@ namespace nt2
    * solve for x the system xa = b ( c = ctrans(linsolve(ctrans(a), ctrans(b));
    *
    * @code
-   *      T x = mrdivide(b, a {, option});
+   *      T x = mrdivide(b, a);
    * @encode
    *
    *    is similar to
    *
    * @code
-   *      T x = ctrans(linsolve(ctrans(a), ctrans(b) {, option});
+   *      T x = ctrans(linsolve(ctrans(a), ctrans(b));
    * @encode
    *
    * Note : @code tie(x, r) = mrdivide(b, a {, option}); @encode
@@ -66,14 +66,13 @@ namespace nt2
    **/
 
   NT2_FUNCTION_IMPLEMENTATION(tag::mrdivide_, mrdivide, 2)
-  NT2_FUNCTION_IMPLEMENTATION(tag::mrdivide_, mrdivide, 3)
 }
 
 namespace nt2 { namespace ext
 {
   template<class Domain, int N, class Expr>
   struct  size_of<tag::mrdivide_,Domain,N,Expr>
-        : meta::size_as<Expr,1>
+        : meta::size_as<Expr,0>
   {};
 
   template<class Domain, int N, class Expr>

--- a/modules/core/linalg/include/nt2/linalg/functions/solvers/mrdivide.hpp
+++ b/modules/core/linalg/include/nt2/linalg/functions/solvers/mrdivide.hpp
@@ -1,0 +1,85 @@
+//==============================================================================
+//         Copyright 2015 J.T. Lapreste
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef NT2_LINALG_FUNCTIONS_SOLVERS_MRDIVIDE_HPP_INCLUDED
+#define NT2_LINALG_FUNCTIONS_SOLVERS_MRDIVIDE_HPP_INCLUDED
+
+#include <nt2/linalg/functions/mrdivide.hpp>
+#include <nt2/core/container/table/table.hpp>
+#include <nt2/include/functions/mtimes.hpp>
+#include <nt2/include/functions/tie.hpp>
+#include <nt2/sdk/meta/settings_of.hpp>
+#include <nt2/linalg/options.hpp>
+#include <nt2/sdk/meta/as_real.hpp>
+#include <nt2/core/container/dsl/as_terminal.hpp>
+
+namespace nt2 { namespace ext
+{
+
+  //============================================================================
+  // MRDIVIDE
+  //============================================================================
+  BOOST_DISPATCH_IMPLEMENT  ( mrdivide_, tag::cpu_
+                            , (A0)(N0)(A1)(N1)
+                            , ((node_<A0, nt2::tag::mrdivide_
+                                    , N0, nt2::container::domain
+                                      >
+                              ))
+                              ((node_<A1, nt2::tag::tie_
+                                    , N1, nt2::container::domain
+                                     >
+                              ))
+                            )
+  {
+    typedef void  result_type;
+    typedef typename boost::proto::result_of::child_c<A0&,0>::value_type child0;
+    typedef typename child0::value_type                                 ctype_t;
+    typedef typename nt2::meta::as_real<ctype_t>::type                   type_t;
+    typedef nt2::memory::container<tag::table_, type_t, nt2::_2D>    o_semantic;
+    BOOST_FORCEINLINE result_type operator()( A0 const& a0, A1 const& a1 ) const
+    {
+      eval(a0,a1,N0(),N1());
+    }
+
+    //==========================================================================
+    /// INTERNAL ONLY - x = mrdivide(b, a)
+    BOOST_FORCEINLINE
+    void eval ( A0 const& a0, A1 const& a1
+              , boost::mpl::long_<2> const&
+              , boost::mpl::long_<1> const&
+              ) const
+    {
+      // it is patent that this can be improved as soon as issue #903 will be addressed
+      boost::proto::child_c<0>(a1) =
+        ctrans(linsolve( ctrans(boost::proto::child_c<1>(a0))
+                       , ctrans(boost::proto::child_c<0>(a0))
+                       )
+              );
+    }
+    //==========================================================================
+    /// INTERNAL ONLY - [x, r]= mrdivide(b, a)
+    BOOST_FORCEINLINE
+    void eval ( A0 const& a0, A1 const& a1
+              , boost::mpl::long_<2> const&
+              , boost::mpl::long_<2> const&
+              ) const
+    {
+      // it is patent that this can be improved as soon as issue #903 will be addressed
+      NT2_AS_TERMINAL_OUT(o_semantic, x, boost::proto::child_c<0>(a1));
+      type_t r;
+      tie(x, r) = linsolve( ctrans(boost::proto::child_c<1>(a0))
+                          , ctrans(boost::proto::child_c<0>(a0))
+                          );
+
+      boost::proto::child_c<0>(a1) = ctrans(x);
+      boost::proto::child_c<1>(a1) = r;
+    }
+
+  };
+} }
+
+#endif

--- a/modules/core/linalg/unit/solvers/CMakeLists.txt
+++ b/modules/core/linalg/unit/solvers/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 SET ( SOURCES
       linsolve.cpp
+      mrdivide.cpp
     )
 
 nt2_module_add_tests(core.linalg.solvers.unit ${SOURCES})

--- a/modules/core/linalg/unit/solvers/mrdivide.cpp
+++ b/modules/core/linalg/unit/solvers/mrdivide.cpp
@@ -1,0 +1,62 @@
+//==============================================================================
+//         Copyright 2003 - 2012   LASMEA UMR 6602 CNRS/Univ. Clermont II
+//         Copyright 2009 - 2013   LRI    UMR 8623 CNRS/Univ Paris Sud XI
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#include <nt2/include/functions/mrdivide.hpp>
+#include <nt2/include/functions/linsolve.hpp>
+#include <nt2/include/functions/ctranspose.hpp>
+#include <nt2/include/functions/cons.hpp>
+
+#include <nt2/table.hpp>
+#include <nt2/sdk/unit/module.hpp>
+#include <nt2/sdk/unit/tests/ulp.hpp>
+#include <nt2/sdk/unit/tests/relation.hpp>
+#include <nt2/sdk/unit/tests/exceptions.hpp>
+
+NT2_TEST_CASE_TPL(mrdivide, NT2_REAL_TYPES )
+{
+using nt2::_;
+using nt2::meta::as_;
+
+
+typedef nt2::table<T,nt2::rectangular_>    t_t;
+
+t_t a = nt2::cons<T>(nt2::of_size(3,3),2,1,1,1,2,2,2,5,7);
+t_t b = nt2::cons<T>(nt2::of_size(1, 3),1,2,5);
+t_t x ;
+t_t x1;
+// X = linsolve(A,B)
+x = ctrans(nt2::linsolve(ctrans(a),ctrans(b)));
+x1= nt2::mrdivide(b, a);
+
+
+NT2_TEST_ULP_EQUAL( x , x1 , 0.5);
+
+
+}
+
+NT2_TEST_CASE_TPL(mrdivide2, NT2_REAL_TYPES )
+{
+using nt2::_;
+using nt2::meta::as_;
+
+
+typedef nt2::table<T,nt2::rectangular_>    t_t;
+
+t_t a = nt2::cons<T>(nt2::of_size(3,3),2,1,1,1,2,2,2,5,7);
+t_t b = nt2::cons<T>(nt2::of_size(1, 3),1,2,5);
+t_t x ;
+t_t x1;
+T r, r1;
+nt2::tie(x, r) = nt2::linsolve(ctrans(a),ctrans(b));
+nt2::tie(x1, r1)= nt2::mrdivide(b, a);
+
+
+NT2_TEST_ULP_EQUAL( ctrans(x) , x1 , 0.5);
+NT2_TEST_ULP_EQUAL( r , r1 , 0.5);
+
+}


### PR DESCRIPTION
mrdivide was missing. This is a version to improve when addressing fully #903 

mrdivide has better use a still non existing option trans_ of linsolve than passing the ctransposed matrix. 