### PR TITLE
Fix #898 - Make is_supported cached

### DIFF
--- a/modules/boost/simd/config/include/boost/simd/sdk/config/is_supported.hpp
+++ b/modules/boost/simd/config/include/boost/simd/sdk/config/is_supported.hpp
@@ -24,7 +24,8 @@ namespace boost { namespace simd
   template<class Tag> inline bool is_supported()
   {
     Tag tag_;
-    return config::details::detect(tag_);
+    static const bool status = config::details::detect(tag_);
+    return status;
   }
 
   inline int is_supported(const char* name)


### PR DESCRIPTION
Improve performance of repeated call to is_supported by caching the first call results.