### PR TITLE
Fix #883 - Correct behavior on some shuffle

### DIFF
--- a/modules/boost/simd/base/include/boost/simd/swar/functions/details/builtin_shuffle.hpp
+++ b/modules/boost/simd/base/include/boost/simd/swar/functions/details/builtin_shuffle.hpp
@@ -1,0 +1,86 @@
+//==============================================================================
+//         Copyright 2003 - 2012 LASMEA UMR 6602 CNRS/Univ. Clermont II
+//         Copyright 2009 - 2012 LRI    UMR 8623 CNRS/Univ Paris Sud XI
+//
+//          Distributed under the Boost Software License, Version 1.0.
+//                 See accompanying file LICENSE.txt or copy at
+//                     http://www.boost.org/LICENSE_1_0.txt
+//==============================================================================
+#ifndef BOOST_SIMD_SWAR_FUNCTIONS_DETAILS_BUILTIN_SHUFFLE_HPP_INCLUDED
+#define BOOST_SIMD_SWAR_FUNCTIONS_DETAILS_BUILTIN_SHUFFLE_HPP_INCLUDED
+
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#define BOOST_SIMD_NO_HAS_BUILTIN
+#endif
+
+#if (defined(__clang__) && __has_builtin(__builtin_shufflevector))                                 \
+ || (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9)))
+
+  #include <boost/preprocessor/repetition/enum.hpp>
+  #include <boost/preprocessor/tuple/elem.hpp>
+  #include <boost/preprocessor/seq/for_each.hpp>
+
+  #ifdef __clang__
+    #define BUILTIN_SHUFFLE2(a, b, n, m) __builtin_shufflevector(a, b, BOOST_PP_ENUM(n, m, n))
+    #define BUILTIN_SHUFFLE1(a, n, seq) __builtin_shufflevector(a, BOOST_PP_ENUM(n, m, n))
+  #else
+    #define BUILTIN_SHUFFLE2(a, b, n, m) __builtin_shuffle(a, b, mask_type{BOOST_PP_ENUM(n, m, n)})
+    #define BUILTIN_SHUFFLE1(a, n, t) __builtin_shuffle(a, mask_type{BOOST_PP_ENUM(n, m, n)})
+  #endif
+
+  #define DEFINE_SHUFFLE2_(z, n, t)                                                                \
+  template<class Dummy>                                                                            \
+  struct impl<n, Dummy>                                                                            \
+  {                                                                                                \
+    BOOST_FORCEINLINE static mask_type call(mask_type const a0, mask_type const a1)                \
+    {                                                                                              \
+      return BUILTIN_SHUFFLE2(a0, a1, n, t);                                                       \
+    }                                                                                              \
+  };                                                                                               \
+
+  #define DEFINE_SHUFFLE2( Tag, Macro )                                                            \
+  BOOST_DISPATCH_IMPLEMENT( Tag, boost::simd::tag::simd_                                           \
+                          , (A0)(A1)(X)                                                            \
+                          , ((simd_< unspecified_<A0>, X >))                                       \
+                            ((simd_< unspecified_<A1>, X >))                                       \
+                          )                                                                        \
+  {                                                                                                \
+    typedef A0 result_type;                                                                        \
+                                                                                                   \
+    typedef typename boost::dispatch::meta::                                                       \
+            as_integer< typename boost::dispatch::meta::primitive_of<A0>::type, signed >::type     \
+    primitive;                                                                                     \
+                                                                                                   \
+    static const int M = sizeof(typename A0::native_type);                                         \
+    typedef typename meta::as_simd<primitive, tag::simd_emulation_<M> >::type mask_type;           \
+                                                                                                   \
+    template<std::size_t N, class Dummy = void>                                                    \
+    struct impl                                                                                    \
+    {                                                                                              \
+      BOOST_FORCEINLINE static mask_type call(mask_type const a0, mask_type const a1)              \
+      {                                                                                            \
+        native<primitive, tag::simd_emulation_<M> > a = a0;                                        \
+        native<primitive, tag::simd_emulation_<M> > b = a1;                                        \
+        return boost::dispatch::functor<tag::Tag, tag::cpu_>()(a, b)();                            \
+      }                                                                                            \
+    };                                                                                             \
+                                                                                                   \
+    BOOST_SIMD_PP_REPEAT_POWER_OF_2_FROM_TO(2, 32, DEFINE_SHUFFLE2_, Macro)                        \
+                                                                                                   \
+    BOOST_FORCEINLINE result_type operator()(A0 const& a0, A1 const& a1) const                     \
+    {                                                                                              \
+      return (typename A0::native_type)impl<A0::static_size>::call((mask_type)a0(), (mask_type)a1());\
+    }                                                                                              \
+  };                                                                                               \
+  /**/
+
+#else
+  #define DEFINE_SHUFFLE2(Tag, Seq)
+#endif
+
+#ifdef BOOST_SIMD_NO_HAS_BUILTIN
+#undef __has_builtin
+#endif
+
+#endif

--- a/modules/boost/simd/base/include/boost/simd/swar/functions/simd/common/interleave_even.hpp
+++ b/modules/boost/simd/base/include/boost/simd/swar/functions/simd/common/interleave_even.hpp
@@ -17,6 +17,8 @@
 #include <boost/simd/sdk/meta/as_arithmetic.hpp>
 #include <boost/simd/sdk/meta/cardinal_of.hpp>
 
+#include <boost/simd/swar/functions/details/builtin_shuffle.hpp>
+
 namespace boost { namespace simd { namespace ext
 {
   BOOST_DISPATCH_IMPLEMENT          ( interleave_even_, tag::cpu_
@@ -57,6 +59,13 @@ namespace boost { namespace simd { namespace ext
       );
     }
   };
+
+  #define M_IEVEN(z,n,t) (n%2 ? (t+n-1) : n)
+  DEFINE_SHUFFLE2(  interleave_even_,
+                    M_IEVEN
+                 )
+  #undef M_IEVEN
+
 } } }
 
 #endif

--- a/modules/boost/simd/base/include/boost/simd/swar/functions/simd/common/interleave_even.hpp
+++ b/modules/boost/simd/base/include/boost/simd/swar/functions/simd/common/interleave_even.hpp
@@ -61,7 +61,7 @@ namespace boost { namespace simd { namespace ext
   };
 
   #define M_IEVEN(z,n,t) (n%2 ? (t+n-1) : n)
-  DEFINE_SHUFFLE2(  interleave_even_,
+  BOOST_SIMD_DEFINE_SHUFFLE2(  interleave_even_,
                     M_IEVEN
                  )
   #undef M_IEVEN

--- a/modules/boost/simd/base/include/boost/simd/swar/functions/simd/common/interleave_odd.hpp
+++ b/modules/boost/simd/base/include/boost/simd/swar/functions/simd/common/interleave_odd.hpp
@@ -17,6 +17,8 @@
 #include <boost/simd/sdk/meta/as_arithmetic.hpp>
 #include <boost/simd/sdk/meta/cardinal_of.hpp>
 
+#include <boost/simd/swar/functions/details/builtin_shuffle.hpp>
+
 namespace boost { namespace simd { namespace ext
 {
   BOOST_DISPATCH_IMPLEMENT          ( interleave_odd_, tag::cpu_
@@ -57,6 +59,13 @@ namespace boost { namespace simd { namespace ext
       );
     }
   };
+
+  #define M_IODD(z,n,t) (n%2 ? (t+n) : n+1)
+  DEFINE_SHUFFLE2(  interleave_odd_,
+                    M_IODD
+                 )
+  #undef M_IODD
+
 } } }
 
 #endif

--- a/modules/boost/simd/base/include/boost/simd/swar/functions/simd/common/interleave_odd.hpp
+++ b/modules/boost/simd/base/include/boost/simd/swar/functions/simd/common/interleave_odd.hpp
@@ -61,7 +61,7 @@ namespace boost { namespace simd { namespace ext
   };
 
   #define M_IODD(z,n,t) (n%2 ? (t+n) : n+1)
-  DEFINE_SHUFFLE2(  interleave_odd_,
+  BOOST_SIMD_DEFINE_SHUFFLE2(  interleave_odd_,
                     M_IODD
                  )
   #undef M_IODD


### PR DESCRIPTION
Shuffle on some type/architecture were not generated properly. Thsi use the builtin_shuffle facilities of gcc/clang to fix this.